### PR TITLE
[Refactor] MapView 생명주기 관리 및 리소스 정리 방식 개선

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/data/dto/RoomDataDto.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/dto/RoomDataDto.kt
@@ -1,7 +1,5 @@
 package com.and04.naturealbum.data.dto
 
-import java.time.LocalDateTime
-
 data class AlbumDto(
     val labelId: Int,
     val labelName: String,

--- a/app/src/main/java/com/and04/naturealbum/ui/friend/navigation/FriendSearchNavigation.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/friend/navigation/FriendSearchNavigation.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.and04.naturealbum.ui.friend.FriendSearchScreen
+import com.and04.naturealbum.ui.mypage.friendsearch.FriendSearchScreen
 import com.and04.naturealbum.ui.navigation.NatureAlbumNavigator
 import com.and04.naturealbum.ui.navigation.NavigateDestination
 

--- a/app/src/main/java/com/and04/naturealbum/ui/maps/MapScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/maps/MapScreen.kt
@@ -1,7 +1,6 @@
 package com.and04.naturealbum.ui.maps
 
 import android.graphics.PointF
-import android.util.Log
 import android.view.Gravity
 import android.view.View
 import androidx.activity.compose.BackHandler
@@ -70,7 +69,6 @@ import com.naver.maps.map.NaverMap
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.Overlay
 import com.naver.maps.map.overlay.OverlayImage
-import java.util.UUID
 
 @Composable
 fun MapScreen(
@@ -79,10 +77,6 @@ fun MapScreen(
     userViewModel: MapScreenViewModel = hiltViewModel(),
     networkViewModel: NetworkViewModel = hiltViewModel(),
 ) {
-    // 고유 식별자를 생성해 MapScreen 인스턴스를 추적
-    val instanceId = remember { UUID.randomUUID().toString() }
-    Log.d("MapScreen", "New MapScreen instance created: $instanceId")
-
     val context = LocalContext.current
     val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 
@@ -223,78 +217,35 @@ fun MapScreen(
         }
     }
 
-    // MapView의 생명주기를 관리하기 위해 DisposableEffect를 사용
     DisposableEffect(lifecycleOwner) {
-        // 현재 LifecycleOwner의 Lifecycle을 가져오기
         val lifecycle = lifecycleOwner.lifecycle
 
-        Log.d("MapScreen", "LifecycleOwner class: ${lifecycleOwner::class.java}")
-        Log.d("MapScreen", "Lifecycle class: ${lifecycle::class.java}")
+        val observer = object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_CREATE -> mapView.onCreate(null)
+                    Lifecycle.Event.ON_START -> mapView.onStart()
+                    Lifecycle.Event.ON_RESUME -> mapView.onResume()
+                    Lifecycle.Event.ON_PAUSE -> mapView.onPause()
+                    Lifecycle.Event.ON_STOP -> mapView.onStop()
+                    Lifecycle.Event.ON_DESTROY -> {
+                        clusterManagers.forEach { cluster ->
+                            cluster.clear()
+                        }
+                        mapView.onDestroy()
+                        lifecycle.removeObserver(this)
+                    }
 
-        // MapView 상태 추적 변수
-        var mapViewState = "INITIALIZED"
-
-        // Lifecycle 이벤트를 관찰하는 Observer를 생성
-        val observer = LifecycleEventObserver { _, event ->
-            Log.d("MapScreen", "Lifecycle event: $event")
-
-            when (event) {
-                Lifecycle.Event.ON_CREATE -> {
-                    mapView.onCreate(null)
-                    mapViewState = "CREATED"
+                    else -> {}
                 }
-
-                Lifecycle.Event.ON_START -> {
-                    mapView.onStart()
-                    mapViewState = "STARTED"
-                }
-
-                Lifecycle.Event.ON_RESUME -> {
-                    mapView.onResume()
-                    mapViewState = "RESUMED"
-                }
-
-                Lifecycle.Event.ON_PAUSE -> {
-                    mapView.onPause()
-                    mapViewState = "PAUSED"
-                }
-
-                Lifecycle.Event.ON_STOP -> {
-                    mapView.onStop()
-                    mapViewState = "STOPPED"
-                }
-
-                Lifecycle.Event.ON_DESTROY -> {
-                    mapView.onDestroy()
-                    mapViewState = "DESTROYED"
-                    Log.d("MapScreen", "ON_DESTROY 발생 mapView onDestroy 완료")
-                }
-
-                else -> {}
             }
-
-            // MapView 상태 로그 출력
-            Log.d("MapScreen", "MapView current state: $mapViewState")
         }
 
-        // Lifecycle에 Observer를 추가하여 생명주기를 관찰
         lifecycle.addObserver(observer)
 
-        // DisposableEffect가 해제될 때 Observer를 제거하고 MapView의 리소스를 해제
         onDispose {
-            Log.d("MapScreen", "DisposableEffect disposed, cleaning up MapView")
-
-            //lifecycle.removeObserver(observer)
-            clusterManagers.forEach { cluster ->
-                cluster.clear()
-            }
-            mapView.onDestroy() // MapView의 리소스를 해제하여 메모리 누수를 방지
-
-            mapViewState = "DISPOSED"
-            Log.d("MapScreen", "MapView final state: $mapViewState")
         }
     }
-
 
     Box(modifier = modifier.fillMaxSize()) {
         if (networkState.value == NetworkState.DISCONNECTED) {


### PR DESCRIPTION
### ✅ **작업 목록**

1. **`MapView` 생명주기 관리 개선**:
    - `LifecycleEventObserver`를 활용하여 `MapView`와 `ClusterManager`의 리소스를 `ON_DESTROY` 이벤트에서 정리하도록 수정.
2. **익명 클래스를 활용한 Observer 구현**:
    - `this` 참조 문제 해결을 위해 `LifecycleEventObserver`를 익명 클래스로 구현.
    - 이를 통해 `lifecycle.removeObserver(this)` 호출 시 올바른 참조를 사용하도록 수정.
3. **코드 통일성과 유지보수성 향상**:
    - `ON_DESTROY`에서 `MapView`와 관련된 리소스를 정리하여 Navigation 생명주기와 동기화.
    - `onDispose`는 Compose 생명주기를 고려하여 최소 작업만 수행하도록 해야 하지만 현재는 정리해야 할 작업이 없음.
        - 참고: `DisposableEffect`는 `onDispose` 절을 코드 블록의 최종 문장으로 포함해야 함.  그러지 않으면 IDE에 빌드 시간 오류가 표시됨.
            
            https://developer.android.com/develop/ui/compose/side-effects?hl=ko
            
4. **추가 로그 및 문제 디버깅**:
    - `ON_DESTROY` 및 `onDispose` 호출 순서를 확인하기 위한 로그 추가하여 확인함
    - 앱 종료 및 화면 전환 시 생명주기 이벤트 순서를 점검하여 문제를 재현 및 해결.

---

### 💡 **Refactoring 이유**

**MapScreen 화면 Navigation 생명주기와 동기화**:

- `NavBackStackEntry`의 생명주기(`ON_DESTROY`)를 기준으로 `MapView` 관련 리소스를 정리하여 기존의 xml, compose 혼용 아이디어 대로 진행.
- 다른 이벤트와 동일하게 코드 통일성을 유지하며,현재의 동작(화면 생성/제거)이 유지되며, 백스택 재사용 로직이나 상태 복원 요구사항 발생 시에도 쉽게 적용 가능

---

### ☑️ 참고 로그

- `ON_DESTROY`와 `onDispose` 호출 순서 분석 결과:
    - 일반적인 화면 전환: `onDispose` → `ON_DESTROY`
    - 앱 종료 시: `ON_DESTROY` → `onDispose`

---

### 📑 자세한 사항은 문서 확인
[[개발문서]_MapView_생명주기_관리_개선](https://github.com/boostcampwm-2024/refactor-and04-Nature-Album/wiki/%5B%EA%B0%9C%EB%B0%9C%EB%AC%B8%EC%84%9C%5D_MapView_%EC%83%9D%EB%AA%85%EC%A3%BC%EA%B8%B0_%EA%B4%80%EB%A6%AC_%EA%B0%9C%EC%84%A0)