### PR TITLE
[Refactor] 지도 경계(LatLngBounds) 계산 시간 복잡도 O(N²) → O(N)  최적화

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/ui/maps/MapScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/maps/MapScreen.kt
@@ -58,9 +58,9 @@ import com.and04.naturealbum.ui.component.NetworkDisconnectContent
 import com.and04.naturealbum.ui.component.PartialBottomSheet
 import com.and04.naturealbum.ui.component.PhotoContent
 import com.and04.naturealbum.ui.utils.UserManager
+import com.and04.naturealbum.utils.color.toColor
 import com.and04.naturealbum.utils.network.NetworkState
 import com.and04.naturealbum.utils.network.NetworkViewModel
-import com.and04.naturealbum.utils.color.toColor
 import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraAnimation
 import com.naver.maps.map.CameraUpdate
@@ -203,10 +203,8 @@ fun MapScreen(
         val totalPhotos = photosByUid.value.values.flatten()
         if (totalPhotos.isNotEmpty()) {
             val bound = LatLngBounds.Builder().apply {
-                photosByUid.value.values.forEach { photoItems ->
-                    photoItems.forEach { photoItem ->
-                        include(photoItem.position)
-                    }
+                totalPhotos.forEach { photoItem ->
+                    include(photoItem.position)
                 }
             }.build()
             mapView.getMapAsync { naverMap ->

--- a/app/src/test/java/com/and04/naturealbum/maps/MapBoundaryCalculationTest.kt
+++ b/app/src/test/java/com/and04/naturealbum/maps/MapBoundaryCalculationTest.kt
@@ -48,8 +48,8 @@ class MapBoundaryCalculationTest {
 
     @Test
     fun testBoundaryCalculationPerformance() {
-        val photoCounts = listOf(1000, 10000, 50000)
-        val iterations = 3
+        val photoCounts = listOf(1000, 5000, 10000, 50000, 100000, 200000, 400000, 500000)
+        val iterations = 5
 
         photoCounts.forEach { count ->
 

--- a/app/src/test/java/com/and04/naturealbum/maps/MapBoundaryCalculationTest.kt
+++ b/app/src/test/java/com/and04/naturealbum/maps/MapBoundaryCalculationTest.kt
@@ -1,0 +1,78 @@
+package com.and04.naturealbum
+
+import com.and04.naturealbum.ui.maps.LabelItem
+import com.and04.naturealbum.ui.maps.PhotoItem
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDateTime
+import kotlin.system.measureTimeMillis
+
+class MapBoundaryCalculationTest {
+
+    private fun generateDummyPhotos(count: Int): List<PhotoItem> {
+        return List(count) {
+            PhotoItem(
+                uri = "photo_$it",
+                position = LatLng(37.0 + it * 0.001, 127.0 + it * 0.001),
+                label = LabelItem("Label_${it % 5}", "#FF0000"), // 5개의 라벨로 그룹화
+                time = LocalDateTime.now()
+            )
+        }
+    }
+
+    // 기존 방식: 2중 for문
+    private fun measureOriginalBoundaryCalculationTime(photoItems: Map<String, List<PhotoItem>>): Long {
+        return measureTimeMillis {
+            LatLngBounds.Builder().apply {
+                photoItems.values.forEach { photoList ->
+                    photoList.forEach { photoItem ->
+                        include(photoItem.position)
+                    }
+                }
+            }.build()
+        }
+    }
+
+    // 리팩토링 방식: 이미 flatten 해둔 totalPhotos를 사용할 경우
+    private fun measureOptimizedBoundaryCalculationTime(photoItems: List<PhotoItem>): Long {
+        return measureTimeMillis {
+            LatLngBounds.Builder().apply {
+                photoItems.forEach { photoItem ->
+                    include(photoItem.position)
+                }
+            }.build()
+        }
+    }
+
+    @Test
+    fun testBoundaryCalculationPerformance() {
+        val photoCounts = listOf(1000, 10000, 50000)
+        val iterations = 3
+
+        photoCounts.forEach { count ->
+
+            val dummyPhotos = generateDummyPhotos(count)
+            val photosByUid = dummyPhotos.groupBy { it.label.name } // Map 형태로 변환
+
+            var originalTotalTime = 0L
+            var optimizedTotalTime = 0L
+
+            repeat(iterations) {
+                originalTotalTime += measureOriginalBoundaryCalculationTime(photosByUid)
+                optimizedTotalTime += measureOptimizedBoundaryCalculationTime(dummyPhotos)
+            }
+
+            val originalAvgTime = originalTotalTime / iterations
+            val optimizedAvgTime = optimizedTotalTime / iterations
+
+            println("사진 개수: $count")
+            println("기존 방식 평균 시간: $originalAvgTime ms")
+            println("리팩토링 방식 평균 시간 (단일 리스트): $optimizedAvgTime ms")
+            println("---")
+
+            assertTrue("리팩토링이 기존 방식보다 느립니다.", optimizedAvgTime <= originalAvgTime)
+        }
+    }
+}

--- a/app/src/test/java/com/and04/naturealbum/maps/MapBoundaryCalculationTest.kt
+++ b/app/src/test/java/com/and04/naturealbum/maps/MapBoundaryCalculationTest.kt
@@ -1,4 +1,4 @@
-package com.and04.naturealbum
+package com.and04.naturealbum.maps
 
 import com.and04.naturealbum.ui.maps.LabelItem
 import com.and04.naturealbum.ui.maps.PhotoItem
@@ -12,11 +12,11 @@ import kotlin.system.measureTimeMillis
 class MapBoundaryCalculationTest {
 
     private fun generateDummyPhotos(count: Int): List<PhotoItem> {
-        return List(count) {
+        return List(count) { index ->
             PhotoItem(
-                uri = "photo_$it",
-                position = LatLng(37.0 + it * 0.001, 127.0 + it * 0.001),
-                label = LabelItem("Label_${it % 5}", "#FF0000"), // 5개의 라벨로 그룹화
+                uri = "photo_$index",
+                position = LatLng(37.0 + index * 0.001, 127.0 + index * 0.001),
+                label = LabelItem("Label_${index % 5}", "#FF0000"),
                 time = LocalDateTime.now()
             )
         }


### PR DESCRIPTION
# ✅ 진행한 기능

- LatLngBounds 계산 로직 시간 복잡도를 O(N²)에서 O(N)으로 최적화
- 유닛 테스트 추가

### **📌 작업 요약**

- 지도 경계 영역(LatLngBounds) 계산 로직의 `시간 복잡도를 O(N²)에서 O(N)으로 최적화`하였습니다.
- 기존의 비효율적인 `중첩 루프를 제거`하고, 이미 생성된 `flatten` 리스트를 활용하여 단일 루프 기반의 계산으로 개선하였습니다.
    
   ![image](https://github.com/user-attachments/assets/9c9f17a8-98c6-436f-ae53-6f91cadb1c17)905ac7915211/image.png)
    
- 테스트를 통해 리팩토링 전후 성능을 비교하며 최적화 효과를 검증하였습니다.
    - 다양한 사진 개수 데이터셋(1,000 ~ 500,000)에서 성능 차이를 평균적으로 비교
        
       ![image](https://github.com/user-attachments/assets/247c5027-a7ee-4163-a663-5bbfa0a7b690)
        

### ⭐ 참고 사항
- 아래의 동작을 수행하는 부분을 리팩토링한 것입니다. 


https://github.com/user-attachments/assets/e7462a45-9abe-4f05-becb-60e34114d937


- 현재 앱에서는 대규모 데이터를 처리할 일이 드물지만, 이후 데이터 규모가 증가하고 실시간성이 중요한 기능이 추가될 경우, 이번 작업이 더 유의미하게 작용할 것으로 보입니다. 특히 UI 렌더링 반응성이 빨라져 사용자 경험에 중요한 역할을 할 것 같습니다.
- 테스트를 통해 시간 복잡도 감소가 실제 성능에 미치는 영향을 확인하며, 최적화의 필요성과 효과를 직접 체감할 수 있었습니다.
- 자세한 진행 내용은 문서를 참고해주세요!
- [[개발문서]_LatLngBounds_계산_O(N²)→O(N)_시간_복잡도_최적화](https://github.com/boostcampwm-2024/refactor-and04-Nature-Album/wiki/%5B%EA%B0%9C%EB%B0%9C%EB%AC%B8%EC%84%9C%5D_LatLngBounds_%EA%B3%84%EC%82%B0_O(N%C2%B2)%E2%86%92O(N)_%EC%8B%9C%EA%B0%84_%EB%B3%B5%EC%9E%A1%EB%8F%84_%EC%B5%9C%EC%A0%81%ED%99%94)